### PR TITLE
feat: Separate authentication routes into auth.php

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -6,14 +6,11 @@ use App\Models\User;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 
 class AuthenticatedSessionController extends Controller
 {
-    /**
-     * Handle an incoming authentication request.
-     */
+    //Handle an incoming authentication request.
     public function store(Request $request)
     {
         //validate the request
@@ -43,9 +40,7 @@ class AuthenticatedSessionController extends Controller
         ]);
     }
 
-    /**
-     * Destroy an authenticated session.
-     */
+    //Destroy an authenticated session.
     public function destroy(Request $request)
     {
         //remove the user's token(Logout)

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -6,8 +6,6 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
-use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rules;
 

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        parent::boot();
+    }
+
+    public function map()
+    {
+        $this->mapApiRoutes();
+    }
+
+    protected function mapApiRoutes()
+    {
+        Route::prefix('api')
+            ->middleware('api')
+            ->group(base_path('routes/api.php'));
+    }
+}

--- a/database/migrations/2024_12_17_092434_create_personal_access_tokens_table.php
+++ b/database/migrations/2024_12_17_092434_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->string('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,41 +1,12 @@
 <?php
 
-use App\Http\Controllers\Auth\AuthenticatedSessionController;
-use App\Http\Controllers\Auth\EmailVerificationNotificationController;
-use App\Http\Controllers\Auth\NewPasswordController;
-use App\Http\Controllers\Auth\PasswordResetLinkController;
-use App\Http\Controllers\Auth\RegisteredUserController;
-use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
-use Illuminate\Foundation\Auth\EmailVerificationRequest;
 
-//routes for registration
-Route::middleware('api')->post('/register', [RegisteredUserController::class, 'store'])
-    ->name('register');
+// Include authentication routes
+Route::prefix('auth')->group(function () {
+    require base_path('routes/auth.php');
+});
 
-//routes for login
-Route::middleware('api')->post('/login', [AuthenticatedSessionController::class, 'store'])
-    ->name('login');
-
-//routes for forgot password
-Route::middleware('api')->post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-    ->name('password.email');
-
-//routes for reset password
-Route::middleware('api')->post('/reset-password', [NewPasswordController::class, 'store'])
-    ->name('password.update');
-
-//routes for email verification(using 'auth:sanctum' middleware)
-Route::middleware(['auth:sanctum', 'signed'])->get('/verify-email/{id}/{hash}', function (EmailVerificationRequest $request) {
-    $request->fulfill();
-
-    return response()->json(['message' => 'Email verified successfully.']);
-})->name('verification.verify');
-
-//route to resend email verification notification(using 'auth:sanctum' middleware)
-Route::middleware(['auth:sanctum'])->post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-    ->name('verification.send');
-
-// route to handle authenticated user logout(using 'auth:sanctum' middleware)
-Route::middleware(['auth:sanctum'])->post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-    ->name('logout');
+Route::get('/status', function () {
+    return response()->json(['status' => 'API is running'], 200);
+});

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -5,34 +5,32 @@ use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\NewPasswordController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
-use App\Http\Controllers\Auth\VerifyEmailController;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Foundation\Auth\EmailVerificationRequest;
 
-/*Route::post('/register', [RegisteredUserController::class, 'store'])
-    ->middleware('guest')
-    ->name('register');
+//user registration route
+Route::post('/register', [RegisteredUserController::class, 'store'])->name('auth.register');
 
-Route::post('/login', [AuthenticatedSessionController::class, 'store'])
-    ->middleware('guest')
-    ->name('login');
+//user login route
+Route::post('/login', [AuthenticatedSessionController::class, 'store'])->name('auth.login');
 
-Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])
-    ->middleware('guest')
-    ->name('password.email');
+//forgot-password route
+Route::post('/forgot-password', [PasswordResetLinkController::class, 'store'])->name('auth.password.email');
 
-Route::post('/reset-password', [NewPasswordController::class, 'store'])
-    ->middleware('guest')
-    ->name('password.store');
+//reset password route
+Route::post('/reset-password', [PasswordResetLinkController::class, 'store'])->name('auth.password.update');
 
-Route::get('/verify-email/{id}/{hash}', VerifyEmailController::class)
-    ->middleware(['auth', 'signed', 'throttle:6,1'])
-    ->name('verification.verify');
+//email verification route(using 'auth:sanctum' middleware)
+Route::middleware(['auth:sanctum', 'signed'])->get('/verify-email/{id}/{hash}', function (EmailVerificationRequest $request) {
+    $request->fulfill();
 
-Route::post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
-    ->middleware(['auth', 'throttle:6,1'])
+    return response()->json(['message' => 'Email verified successfully.']);
+})->name('verification.verify');
+
+//route to resend email verification notification(using 'auth:sanctum' middleware)
+Route::middleware(['auth:sanctum'])->post('/email/verification-notification', [EmailVerificationNotificationController::class, 'store'])
     ->name('verification.send');
 
-Route::post('/logout', [AuthenticatedSessionController::class, 'destroy'])
-    ->middleware('auth')
-    ->name('logout');
-*/
+// route to handle authenticated user logout(using 'auth:sanctum' middleware)
+Route::middleware(['auth:sanctum'])->post('/logout', [AuthenticatedSessionController::class, 'destroy'])
+    ->name('auth.logout');


### PR DESCRIPTION
- Moved all authentication-related routes from api.php to a dedicated auth.php file.
- Scoped authentication routes under the `api/auth` prefix for better organization.
- Ensured middleware consistency, applying `auth:sanctum` where necessary.