### PR TITLE
feat: Implement addAdmin functionality for Super Admin

### DIFF
--- a/app/Http/Controllers/AdminController.php
+++ b/app/Http/Controllers/AdminController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Auth;
+
+class AdminController extends Controller
+{
+    
+    public function addAdmin(Request $request){
+        //check if the authenticated user is a super admin
+        if(!Auth::check()|| Auth::user()->role !== 'super_admin'){
+            return response()->json([
+                'message'=>'Forbidden'
+            ],403);
+        }
+
+        //validate the input
+        $validator =Validator::make($request->all(),[
+            'email'=>'required|email|unique:users,email',
+            'username'=>'required|string|max:225|unique:users,username',
+            'password'=>'required|string|min:8',
+            'user_image'=>'nullable|image|mimes:jpeg,png,jpg,gif|max:2048',
+            'phone_no'=>'nullable|string|max:15',
+            'address'=>'nullable|string|max:255',
+            'first_name'=>'required|string|max:255',
+            'last_name'=>'required|string|max:255',
+        ]);
+
+        if($validator->fails()){
+            return response()->json([
+                'errors'=>'$validator->errors()'
+            ],422);
+        }
+
+        //Handle the user image upload if provided
+        $imagePath=null;
+        if($request->hasFile('user_image')){
+            $imagePath = $request->file('user_image')->store('user_image','public');
+        }
+
+         //create a new admin 
+         $admin=User::create([
+            'email'=>$request->email,
+            'username'=>$request->username,
+            'password'=>Hash::make($request->password),
+            'role'=>'admin',
+            'user_image'=>$imagePath,
+            'phone_no'=>$request->phone_no,
+            'address' => $request->address,
+            'first_name' => $request->first_name,
+            'last_name' => $request->last_name,
+         ]);
+
+         return response()->json([
+            'message'=>'Admin created successfully',
+            'admin'=>$admin
+         ],201);
+
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,7 +24,12 @@ class User extends Authenticatable implements MustVerifyEmail
         'email',
         'username',
         'password',
-        'role', 
+        'role',
+        'user_image',
+        'phone_no',
+        'address',
+        'first_name',
+        'last_name', 
     ];
 
     /**

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Auth\AuthenticatedSessionController;
 use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\RegisteredUserController;
+use App\Http\Controllers\AdminController;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Auth\EmailVerificationRequest;
 
@@ -33,3 +34,6 @@ Route::middleware(['auth:sanctum'])->post('/email/verification-notification', [E
 // route to handle authenticated user logout(using 'auth:sanctum' middleware)
 Route::middleware(['auth:sanctum'])->post('/logout', [AuthenticatedSessionController::class, 'destroy'])
     ->name('auth.logout');
+
+// Route to add a new admin (only accessible to super admin, using 'auth:sanctum' middleware)
+Route::middleware(['auth:sanctum'])->post('/add-admin', [AdminController::class, 'addAdmin'])->name('admin.add');


### PR DESCRIPTION
- Added the `addAdmin` method in `AdminController` to allow Super Admin to add new admins.
- Validated inputs for email, username, password, role, and additional user details.
- Ensured only Super Admins can access this feature with role-based authorization.
- Created a new API route `/add-admin` with `auth:sanctum` middleware.